### PR TITLE
Unify the whole project to use QString instead of std::string.

### DIFF
--- a/source/QuickCut/ActionEditWindow.cpp
+++ b/source/QuickCut/ActionEditWindow.cpp
@@ -47,18 +47,18 @@ void ActionEditWindow::fillActionTypes()
 
 void ActionEditWindow::fillEntries()
 {
-    ui->tbxName->setText(QString::fromStdString(m_Action->getName()));
+    ui->tbxName->setText(m_Action->getName());
 
     int typeIndex = static_cast<int>(m_Action->getType());
     ui->cbxType->setCurrentIndex(typeIndex);
     onTypeSelChange(typeIndex);
 
-    // ui->tbxSrcKey->setKeySequence(QKeySequence::fromString(QString::fromStdString(m_Action->getSrcKey())));
-    // ui->tbxDstKey->setKeySequence(QKeySequence::fromString(QString::fromStdString(m_Action->getDstKey())));
-    ui->tbxSrcKey->setText(QString::fromStdString(m_Action->getSrcKey()));
-    ui->tbxDstKey->setText(QString::fromStdString(m_Action->getDstKey()));
-    ui->tbxAppPath->setText(QString::fromStdString(m_Action->getAppPath()));
-    ui->tbxAppArgs->setText(QString::fromStdString(m_Action->getAppArgs()));
+    // ui->tbxSrcKey->setKeySequence(QKeySequence::fromString(m_Action->getSrcKey()));
+    // ui->tbxDstKey->setKeySequence(QKeySequence::fromString(m_Action->getDstKey()));
+    ui->tbxSrcKey->setText(m_Action->getSrcKey());
+    ui->tbxDstKey->setText(m_Action->getDstKey());
+    ui->tbxAppPath->setText(m_Action->getAppPath());
+    ui->tbxAppArgs->setText(m_Action->getAppArgs());
 }
 
 void ActionEditWindow::connectSlots()
@@ -167,17 +167,17 @@ void ActionEditWindow::onBtnSave()
 
     eActionType type = static_cast<eActionType>(ui->cbxType->currentIndex());
 
-    m_Action->setName(ui->tbxName->text().toStdString());
+    m_Action->setName(ui->tbxName->text());
     m_Action->setType(type);
-    m_Action->setSrcKey(ui->tbxSrcKey->text().toStdString());
-    // m_Action->setSrcKey(ui->tbxSrcKey->keySequence().toString().toStdString());
+    m_Action->setSrcKey(ui->tbxSrcKey->text());
+    // m_Action->setSrcKey(ui->tbxSrcKey->keySequence().toString());
     // if (type == ActionKeyMap) {
-    // m_Action->setDstKey(ui->tbxDstKey->keySequence().toString().toStdString()); }
-    if (type == ActionKeyMap) { m_Action->setDstKey(ui->tbxDstKey->text().toStdString()); }
+    // m_Action->setDstKey(ui->tbxDstKey->keySequence().toString()); }
+    if (type == ActionKeyMap) { m_Action->setDstKey(ui->tbxDstKey->text()); }
     else if (type == ActionAppStart)
     {
-        m_Action->setAppPath(ui->tbxAppPath->text().toStdString());
-        m_Action->setAppArgs(ui->tbxAppArgs->text().toStdString());
+        m_Action->setAppPath(ui->tbxAppPath->text());
+        m_Action->setAppArgs(ui->tbxAppArgs->text());
     }
 
     if (m_EditMode == ActionCreate)

--- a/source/QuickCut/MainWindow.cpp
+++ b/source/QuickCut/MainWindow.cpp
@@ -233,17 +233,16 @@ void MainWindow::initProfiles()
     }
     else
     {
-        for (auto && profile : m_Profiles)
-            ui->cbxProfile->addItem(QString::fromStdString(profile->getName()));
+        for (auto && profile : m_Profiles) ui->cbxProfile->addItem(profile->getName());
 
         Profile * profile = m_Profiles.getActiveProfile();
         if (profile)
         {
-            ui->cbxProfile->setCurrentText(QString::fromStdString(profile->getName()));
+            ui->cbxProfile->setCurrentText(profile->getName());
             if (!profile->getActionManager().empty())
             {
                 for (auto && action : profile->getActionManager())
-                    ui->lbxActions->addItem(QString::fromStdString(action->getName()));
+                    ui->lbxActions->addItem(action->getName());
                 onActionSelChange(0);
             }
             else
@@ -296,7 +295,7 @@ void MainWindow::onProfileSelChange(int index)
     disconnect(ui->lbxActions, &QListWidget::currentRowChanged, this,
                &MainWindow::onActionSelChange);
     for (auto && action : profile->getActionManager())
-        ui->lbxActions->addItem(QString::fromStdString(action->getName()));
+        ui->lbxActions->addItem(action->getName());
     connect(ui->lbxActions, &QListWidget::currentRowChanged, this,
             &MainWindow::onActionSelChange);
 
@@ -343,7 +342,7 @@ Profile * MainWindow::onBtnCreateProfile()
 
     if (!ok && profileName.isEmpty()) return nullptr;
 
-    Profile * profile = m_Profiles.getByName(profileName.toStdString());
+    Profile * profile = m_Profiles.getByName(profileName);
     if (profile)
     {
         QMessageBox::information(this, "Already Exists",
@@ -353,7 +352,7 @@ Profile * MainWindow::onBtnCreateProfile()
     }
 
     profile = new Profile();
-    profile->setName(profileName.toStdString());
+    profile->setName(profileName);
     if (m_Profiles.empty()) profile->setActive(true);
     m_Profiles.add(profile);
     saveProfiles();
@@ -502,7 +501,7 @@ void MainWindow::onActionFileOpen()
 
     if (answer != QMessageBox::Yes) return;
 
-    QString dstFilePath = QString::fromStdString(m_Profiles.getConfigFilePath());
+    QString dstFilePath = m_Profiles.getConfigFilePath();
     if (!QFile::copy(srcFilePath, dstFilePath))
     {
         qDebug() << "[MainWindow::onActionFileOpen] - Failed to copy file from '"
@@ -523,7 +522,7 @@ void MainWindow::onActionFileSaveAs()
                                                        tr("Profiles File (*.json)"));
     if (dstFilePath.isEmpty()) return;
 
-    QString srcFilePath = QString::fromStdString(m_Profiles.getConfigFilePath());
+    QString srcFilePath = m_Profiles.getConfigFilePath();
     if (!QFile::copy(srcFilePath, dstFilePath))
     {
         qDebug() << "[MainWindow::onActionFileSaveAs] - Failed to copy file from '"

--- a/source/QuickCutConsole/QuickCutConsole.cpp
+++ b/source/QuickCutConsole/QuickCutConsole.cpp
@@ -39,7 +39,7 @@ bool QuickCutConsole::loadProfiles()
     if (!s_ProfileManager.load())
     {
         qDebug() << "[QuickCutConsole::loadProfiles] - Failed to load "
-                 << QString::fromStdString(s_ProfileManager.getConfigFilePath()) << " file.";
+                 << s_ProfileManager.getConfigFilePath() << " file.";
         return false;
     }
 
@@ -48,20 +48,19 @@ bool QuickCutConsole::loadProfiles()
     return true;
 }
 
-void QuickCutConsole::executeProcess(const std::string & process,
-                                     const std::string & arguments)
+void QuickCutConsole::executeProcess(const QString & process, const QString & arguments)
 {
     // QProc won't expand environment variable strings.
     // Invoking using the user console will allow for expanded string to work as expected.
 #if defined(Q_OS_WIN)
-    QString command   = "cmd /c start \"\" \"" + QString::fromStdString(process) + "\"";
+    QString command   = "cmd /c start \"\" \"" + process + "\"";
     QString extension = ".cmd";
 #elif defined(Q_OS_UNIX)
-    QString command   = "sh -c '" + QString::fromStdString(process) + "'";
+    QString command   = "sh -c '" + process + "'";
     QString extension = ".sh";
 #endif
 
-    QStringList argsTmp = QString::fromStdString(arguments).trimmed().split(",");
+    QStringList argsTmp = arguments.trimmed().split(",");
     for (auto && arg : argsTmp)
     {
         QString argTrimmed = arg.trimmed();

--- a/source/QuickCutConsole/QuickCutConsole.h
+++ b/source/QuickCutConsole/QuickCutConsole.h
@@ -18,7 +18,7 @@ public:
     virtual bool stop();
 
     static bool loadProfiles();
-    static void executeProcess(const std::string & process, const std::string & arguments);
+    static void executeProcess(const QString & process, const QString & arguments);
     static void log(const QString & filePath, const QString & text);
 
 public:

--- a/source/QuickCutConsole/QuickCutConsoleWindows.cpp
+++ b/source/QuickCutConsole/QuickCutConsoleWindows.cpp
@@ -73,18 +73,18 @@ LRESULT CALLBACK QuickCutConsoleWindows::WndProc(int nCode, WPARAM wParam, LPARA
 
         for (auto && action : s_Profile->getActionManager())
         {
-            if (pressedKeys.toStdString() == action->getSrcKey())
+            if (pressedKeys == action->getSrcKey())
             {
                 qDebug() << "Pressed Keys Match!: " << pressedKeys
-                         << " | Actual Keys: " << QString::fromStdString(action->getSrcKey());
+                         << " | Actual Keys: " << action->getSrcKey();
                 eActionType actionType = action->getType();
                 if (actionType == ActionKeyMap)
                 {
                     qDebug() << "Mapping key -> " << pressedKeys << " To -> "
-                             << QString::fromStdString(action->getDstKey());
+                             << action->getDstKey();
                     pressedKeys.clear(); // Make sure to clear keys before sending another key.
                     static int vkDstCode = 0;
-                    vkDstCode = std::strtol(action->getDstKey().c_str(), nullptr, 16);
+                    vkDstCode = std::strtol(qPrintable(action->getDstKey()), nullptr, 16);
 
                     INPUT in  = {0};
                     in.type   = INPUT_KEYBOARD;
@@ -95,9 +95,8 @@ LRESULT CALLBACK QuickCutConsoleWindows::WndProc(int nCode, WPARAM wParam, LPARA
                 }
                 else if (actionType == ActionAppStart)
                 {
-                    qDebug() << "Running process -> "
-                             << QString::fromStdString(action->getAppPath()) << " With key -> "
-                             << pressedKeys;
+                    qDebug() << "Running process -> " << action->getAppPath()
+                             << " With key -> " << pressedKeys;
                     executeProcess(action->getAppPath(), action->getAppArgs());
                 }
             }
@@ -133,8 +132,8 @@ void QuickCutConsoleWindows::printKeyName(KBDLLHOOKSTRUCT * kbd, const QString &
     GetKeyNameText(kbdMsg, reinterpret_cast<LPTSTR>(keyName), sizeof(keyName));
     sprintf_s(keyName, "ScanCode: %d | VirtualKey: 0x%02X | KeyName: %s | Current Keys: %s",
               kbd->scanCode, kbd->vkCode,
-              QString::fromUtf16(reinterpret_cast<ushort *>(keyName)).toStdString().c_str(),
-              pressedKeys.toStdString().c_str());
+              qPrintable(QString::fromUtf16(reinterpret_cast<ushort *>(keyName))),
+              qPrintable(pressedKeys));
     qDebug() << keyName;
 }
 

--- a/source/QuickCutShared/Managers/BaseManager.cpp
+++ b/source/QuickCutShared/Managers/BaseManager.cpp
@@ -48,9 +48,9 @@ void BaseManager<T>::setCapacity(int capacity)
 }
 
 template <typename T>
-T * BaseManager<T>::getById(const std::string & uuid) const
+T * BaseManager<T>::getById(const QString & uuid) const
 {
-    if (uuid.empty()) return nullptr;
+    if (uuid.isEmpty()) return nullptr;
 
     auto itr = std::find_if(m_vData.begin(), m_vData.end(),
                             [&uuid](auto item) { return item->getId() == uuid; });
@@ -60,9 +60,9 @@ T * BaseManager<T>::getById(const std::string & uuid) const
 }
 
 template <typename T>
-T * BaseManager<T>::getByName(const std::string & name) const
+T * BaseManager<T>::getByName(const QString & name) const
 {
-    if (name.empty()) return nullptr;
+    if (name.isEmpty()) return nullptr;
 
     auto itr = std::find_if(m_vData.begin(), m_vData.end(),
                             [&name](auto item) { return item->getName() == name; });

--- a/source/QuickCutShared/Managers/BaseManager.h
+++ b/source/QuickCutShared/Managers/BaseManager.h
@@ -16,8 +16,8 @@ public:
     void clear();
     void setCapacity(int capacity);
 
-    T * getById(const std::string & uuid) const;
-    T * getByName(const std::string & name) const;
+    T * getById(const QString & uuid) const;
+    T * getByName(const QString & name) const;
     T * getByIndex(int index) const;
 
     T *  create();

--- a/source/QuickCutShared/Managers/IParserOperations.h
+++ b/source/QuickCutShared/Managers/IParserOperations.h
@@ -1,15 +1,15 @@
 #pragma once
 
 #include "Types.h"
-#include <string>
+#include <QString>
 
 QCInterface IParserOperations
 {
     virtual bool load() = 0;
     virtual bool save() = 0;
 
-    virtual bool                isLoadSucceed()     = 0;
-    virtual const std::string & getConfigFilePath() = 0;
+    virtual bool            isLoadSucceed()     = 0;
+    virtual const QString & getConfigFilePath() = 0;
 
 protected:
     IParserOperations()          = default;

--- a/source/QuickCutShared/Managers/PreferenceManager.cpp
+++ b/source/QuickCutShared/Managers/PreferenceManager.cpp
@@ -8,13 +8,13 @@ PreferenceManager::PreferenceManager() noexcept
 {
 }
 
-PreferenceManager::PreferenceManager(const std::string & filePath) noexcept
+PreferenceManager::PreferenceManager(const QString & filePath) noexcept
     : m_Parser(filePath)
     , m_LoadSucceed(false)
 {
 }
 
-PreferenceManager::PreferenceManager(std::string && filePath) noexcept
+PreferenceManager::PreferenceManager(QString && filePath) noexcept
     : m_Parser(std::move(filePath))
     , m_LoadSucceed(false)
 {
@@ -38,7 +38,7 @@ bool PreferenceManager::isLoadSucceed()
     return m_LoadSucceed;
 }
 
-const std::string & PreferenceManager::getConfigFilePath()
+const QString & PreferenceManager::getConfigFilePath()
 {
     return m_Parser.getFilePath();
 }

--- a/source/QuickCutShared/Managers/PreferenceManager.h
+++ b/source/QuickCutShared/Managers/PreferenceManager.h
@@ -7,15 +7,15 @@ class PreferenceManager : IParserOperations
 {
 public:
     PreferenceManager() noexcept;
-    PreferenceManager(const std::string & filePath) noexcept;
-    PreferenceManager(std::string && filePath) noexcept;
+    PreferenceManager(const QString & filePath) noexcept;
+    PreferenceManager(QString && filePath) noexcept;
     ~PreferenceManager();
 
     bool load() override;
     bool save() override;
 
-    bool                isLoadSucceed() override;
-    const std::string & getConfigFilePath() override;
+    bool            isLoadSucceed() override;
+    const QString & getConfigFilePath() override;
 
     Preference & get();
 

--- a/source/QuickCutShared/Managers/ProfileManager.cpp
+++ b/source/QuickCutShared/Managers/ProfileManager.cpp
@@ -9,14 +9,14 @@ ProfileManager::ProfileManager() noexcept
 {
 }
 
-ProfileManager::ProfileManager(const std::string & filePath) noexcept
+ProfileManager::ProfileManager(const QString & filePath) noexcept
     : BaseManager()
     , m_Parser(filePath)
     , m_LoadSucceed(false)
 {
 }
 
-ProfileManager::ProfileManager(std::string && filePath) noexcept
+ProfileManager::ProfileManager(QString && filePath) noexcept
     : BaseManager()
     , m_Parser(std::move(filePath))
     , m_LoadSucceed(false)
@@ -41,7 +41,7 @@ bool ProfileManager::isLoadSucceed()
     return m_LoadSucceed;
 }
 
-const std::string & ProfileManager::getConfigFilePath()
+const QString & ProfileManager::getConfigFilePath()
 {
     return m_Parser.getFilePath();
 }

--- a/source/QuickCutShared/Managers/ProfileManager.h
+++ b/source/QuickCutShared/Managers/ProfileManager.h
@@ -9,15 +9,15 @@ class ProfileManager : public BaseManager<Profile>, IParserOperations
 {
 public:
     ProfileManager() noexcept;
-    ProfileManager(const std::string & filePath) noexcept;
-    ProfileManager(std::string && filePath) noexcept;
+    ProfileManager(const QString & filePath) noexcept;
+    ProfileManager(QString && filePath) noexcept;
     ~ProfileManager();
 
     bool load() override;
     bool save() override;
 
-    bool                isLoadSucceed() override;
-    const std::string & getConfigFilePath() override;
+    bool            isLoadSucceed() override;
+    const QString & getConfigFilePath() override;
 
     Profile * getActiveProfile();
     void      setActiveProfile(int index);

--- a/source/QuickCutShared/Models/Action.cpp
+++ b/source/QuickCutShared/Models/Action.cpp
@@ -14,12 +14,12 @@ Action::Action() noexcept
 {
 }
 
-Action::Action(const std::string & name,
+Action::Action(const QString &     name,
                const eActionType & type,
-               const std::string & srcKey,
-               const std::string & dstKey,
-               const std::string & appPath,
-               const std::string & appArgs) noexcept
+               const QString &     srcKey,
+               const QString &     dstKey,
+               const QString &     appPath,
+               const QString &     appArgs) noexcept
     : BaseModel(QuickCut::createUuid(), name, QuickCut::getDateTime())
     , m_Type(type)
     , m_SrcKey(srcKey)
@@ -30,12 +30,12 @@ Action::Action(const std::string & name,
 {
 }
 
-Action::Action(std::string && name,
+Action::Action(QString &&     name,
                eActionType && type,
-               std::string && srcKey,
-               std::string && dstKey,
-               std::string && appPath,
-               std::string && appArgs) noexcept
+               QString &&     srcKey,
+               QString &&     dstKey,
+               QString &&     appPath,
+               QString &&     appArgs) noexcept
     : BaseModel(std::move(QuickCut::createUuid()),
                 std::move(name),
                 std::move(QuickCut::getDateTime()))
@@ -48,15 +48,15 @@ Action::Action(std::string && name,
 {
 }
 
-Action::Action(const std::string & id,
-               const std::string & name,
-               const std::string & lastModified,
+Action::Action(const QString &     id,
+               const QString &     name,
+               const QString &     lastModified,
                const eActionType & type,
-               const std::string & srcKey,
-               const std::string & dstKey,
-               const std::string & appPath,
-               const std::string & appArgs,
-               const std::string & createdDate) noexcept
+               const QString &     srcKey,
+               const QString &     dstKey,
+               const QString &     appPath,
+               const QString &     appArgs,
+               const QString &     createdDate) noexcept
     : BaseModel(id, name, lastModified)
     , m_Type(type)
     , m_SrcKey(srcKey)
@@ -67,15 +67,15 @@ Action::Action(const std::string & id,
 {
 }
 
-Action::Action(std::string && id,
-               std::string && name,
-               std::string && lastModified,
+Action::Action(QString &&     id,
+               QString &&     name,
+               QString &&     lastModified,
                eActionType && type,
-               std::string && srcKey,
-               std::string && dstKey,
-               std::string && appPath,
-               std::string && appArgs,
-               std::string && createdDate) noexcept
+               QString &&     srcKey,
+               QString &&     dstKey,
+               QString &&     appPath,
+               QString &&     appArgs,
+               QString &&     createdDate) noexcept
     : BaseModel(std::move(id), std::move(name), std::move(lastModified))
     , m_Type(std::move(type))
     , m_SrcKey(std::move(srcKey))
@@ -86,7 +86,7 @@ Action::Action(std::string && id,
 {
 }
 
-std::string Action::getType(eActionType type)
+QString Action::getType(eActionType type)
 {
     switch (type)
     {
@@ -101,16 +101,16 @@ std::string Action::getType(eActionType type)
     }
 }
 
-eActionType Action::getType(const std::string & type)
+eActionType Action::getType(const QString & type)
 {
     if (type == "KeyMap") return eActionType::ActionKeyMap;
     if (type == "AppStart") return eActionType::ActionAppStart;
     return eActionType::ActionUnknown;
 }
 
-std::string Action::getKey(int key)
+QString Action::getKey(int key)
 {
-    return std::to_string(key);
+    return QString::number(key);
 }
 
 eActionType Action::getType() const
@@ -123,47 +123,47 @@ void Action::setType(eActionType type)
     m_Type = type;
 }
 
-std::string Action::getSrcKey() const
+QString Action::getSrcKey() const
 {
     return m_SrcKey;
 }
 
-void Action::setSrcKey(const std::string & key)
+void Action::setSrcKey(const QString & key)
 {
     m_SrcKey = key;
 }
 
-std::string Action::getDstKey() const
+QString Action::getDstKey() const
 {
     return m_DstKey;
 }
 
-void Action::setDstKey(const std::string & key)
+void Action::setDstKey(const QString & key)
 {
     m_DstKey = key;
 }
 
-const std::string & Action::getAppPath() const
+const QString & Action::getAppPath() const
 {
     return m_AppPath;
 }
 
-void Action::setAppPath(const std::string & path)
+void Action::setAppPath(const QString & path)
 {
     m_AppPath = path;
 }
 
-const std::string & Action::getAppArgs() const
+const QString & Action::getAppArgs() const
 {
     return m_AppArgs;
 }
 
-void Action::setAppArgs(const std::string & args)
+void Action::setAppArgs(const QString & args)
 {
     m_AppArgs = args;
 }
 
-const std::string & Action::getCreatedDate() const
+const QString & Action::getCreatedDate() const
 {
     return m_CreatedDate;
 }

--- a/source/QuickCutShared/Models/Action.h
+++ b/source/QuickCutShared/Models/Action.h
@@ -17,65 +17,65 @@ public:
     Action() noexcept;
 
     // Constructs new Action
-    Action(const std::string & name,
+    Action(const QString &     name,
            const eActionType & type,
-           const std::string & srcKey,
-           const std::string & dstKey,
-           const std::string & appPath,
-           const std::string & appArgs) noexcept;
+           const QString &     srcKey,
+           const QString &     dstKey,
+           const QString &     appPath,
+           const QString &     appArgs) noexcept;
 
-    Action(std::string && name,
+    Action(QString &&     name,
            eActionType && type,
-           std::string && srcKey,
-           std::string && dstKey,
-           std::string && appPath,
-           std::string && appArgs) noexcept;
+           QString &&     srcKey,
+           QString &&     dstKey,
+           QString &&     appPath,
+           QString &&     appArgs) noexcept;
 
     // Constructs existing Action
-    Action(const std::string & id,
-           const std::string & name,
-           const std::string & lastModified,
+    Action(const QString &     id,
+           const QString &     name,
+           const QString &     lastModified,
            const eActionType & type,
-           const std::string & srcKey,
-           const std::string & dstKey,
-           const std::string & appPath,
-           const std::string & appArgs,
-           const std::string & createdDate) noexcept;
+           const QString &     srcKey,
+           const QString &     dstKey,
+           const QString &     appPath,
+           const QString &     appArgs,
+           const QString &     createdDate) noexcept;
 
-    Action(std::string && id,
-           std::string && name,
-           std::string && lastModified,
+    Action(QString &&     id,
+           QString &&     name,
+           QString &&     lastModified,
            eActionType && type,
-           std::string && srcKey,
-           std::string && dstKey,
-           std::string && appPath,
-           std::string && appArgs,
-           std::string && createdDate) noexcept;
+           QString &&     srcKey,
+           QString &&     dstKey,
+           QString &&     appPath,
+           QString &&     appArgs,
+           QString &&     createdDate) noexcept;
 
     // Constructs copy
     Action(const Action & action) = default;
     Action(Action && action)      = default;
 
-    static std::string getType(eActionType type);
-    static eActionType getType(const std::string & type);
-    static std::string getKey(int key);
+    static QString     getType(eActionType type);
+    static eActionType getType(const QString & type);
+    static QString     getKey(int key);
 
     eActionType getType() const;
     void        setType(eActionType type);
 
-    std::string getSrcKey() const;
-    void        setSrcKey(const std::string & key);
+    QString getSrcKey() const;
+    void    setSrcKey(const QString & key);
 
-    std::string getDstKey() const;
-    void        setDstKey(const std::string & key);
+    QString getDstKey() const;
+    void    setDstKey(const QString & key);
 
-    const std::string & getAppPath() const;
-    void                setAppPath(const std::string & path);
+    const QString & getAppPath() const;
+    void            setAppPath(const QString & path);
 
-    const std::string & getAppArgs() const;
-    void                setAppArgs(const std::string & path);
+    const QString & getAppArgs() const;
+    void            setAppArgs(const QString & path);
 
-    const std::string & getCreatedDate() const;
+    const QString & getCreatedDate() const;
 
     void reset();
 
@@ -84,9 +84,9 @@ public:
 
 private:
     eActionType m_Type;
-    std::string m_SrcKey; // string with delimited ',' char. Could have multiple keys.
-    std::string m_DstKey;
-    std::string m_AppPath;
-    std::string m_AppArgs;
-    std::string m_CreatedDate;
+    QString     m_SrcKey; // string with delimited ',' char. Could have multiple keys.
+    QString     m_DstKey;
+    QString     m_AppPath;
+    QString     m_AppArgs;
+    QString     m_CreatedDate;
 };

--- a/source/QuickCutShared/Models/BaseModel.cpp
+++ b/source/QuickCutShared/Models/BaseModel.cpp
@@ -12,40 +12,38 @@ BaseModel::BaseModel() noexcept
 {
 }
 
-BaseModel::BaseModel(std::string && id,
-                     std::string && name,
-                     std::string && lastModified) noexcept
+BaseModel::BaseModel(QString && id, QString && name, QString && lastModified) noexcept
     : m_Uuid(std::move(id))
     , m_Name(std::move(name))
     , m_LastModified(std::move(lastModified))
 {
 }
 
-BaseModel::BaseModel(const std::string & id,
-                     const std::string & name,
-                     const std::string & lastModified) noexcept
+BaseModel::BaseModel(const QString & id,
+                     const QString & name,
+                     const QString & lastModified) noexcept
     : m_Uuid(id)
     , m_Name(name)
     , m_LastModified(lastModified)
 {
 }
 
-const std::string & BaseModel::getId() const
+const QString & BaseModel::getId() const
 {
     return m_Uuid;
 }
 
-const std::string & BaseModel::getName() const
+const QString & BaseModel::getName() const
 {
     return m_Name;
 }
 
-void BaseModel::setName(const std::string & name)
+void BaseModel::setName(const QString & name)
 {
     m_Name = name;
 }
 
-const std::string & BaseModel::getLastModified() const
+const QString & BaseModel::getLastModified() const
 {
     return m_LastModified;
 }

--- a/source/QuickCutShared/Models/BaseModel.h
+++ b/source/QuickCutShared/Models/BaseModel.h
@@ -8,24 +8,22 @@ class BaseModel
 protected:
     BaseModel() noexcept;
 
-    BaseModel(std::string && id, std::string && name, std::string && lastModified) noexcept;
+    BaseModel(QString && id, QString && name, QString && lastModified) noexcept;
 
-    BaseModel(const std::string & id,
-              const std::string & name,
-              const std::string & lastModified) noexcept;
+    BaseModel(const QString & id, const QString & name, const QString & lastModified) noexcept;
 
     virtual ~BaseModel() = default;
 
 public:
-    const std::string & getId() const;
+    const QString & getId() const;
 
-    const std::string & getName() const;
-    void                setName(const std::string & name);
+    const QString & getName() const;
+    void            setName(const QString & name);
 
-    const std::string & getLastModified() const;
+    const QString & getLastModified() const;
 
 protected:
-    std::string m_Uuid;
-    std::string m_Name;
-    std::string m_LastModified;
+    QString m_Uuid;
+    QString m_Name;
+    QString m_LastModified;
 };

--- a/source/QuickCutShared/Models/Profile.cpp
+++ b/source/QuickCutShared/Models/Profile.cpp
@@ -8,19 +8,16 @@ Profile::Profile() noexcept
 {
 }
 
-Profile::Profile(const std::string & id,
-                 const std::string & name,
-                 const std::string & lastModified,
-                 bool                active) noexcept
+Profile::Profile(const QString & id,
+                 const QString & name,
+                 const QString & lastModified,
+                 bool            active) noexcept
     : BaseModel(id, name, lastModified)
     , m_Active(active)
 {
 }
 
-Profile::Profile(std::string && id,
-                 std::string && name,
-                 std::string && lastModified,
-                 bool           active) noexcept
+Profile::Profile(QString && id, QString && name, QString && lastModified, bool active) noexcept
     : BaseModel(std::move(id), std::move(name), std::move(lastModified))
     , m_Active(active)
 {

--- a/source/QuickCutShared/Models/Profile.h
+++ b/source/QuickCutShared/Models/Profile.h
@@ -13,15 +13,15 @@ public:
     Profile() noexcept;
 
     // Constructs existing profile
-    Profile(const std::string & id,
-            const std::string & name,
-            const std::string & lastModified,
-            bool                active = false) noexcept;
+    Profile(const QString & id,
+            const QString & name,
+            const QString & lastModified,
+            bool            active = false) noexcept;
 
-    Profile(std::string && id,
-            std::string && name,
-            std::string && lastModified,
-            bool           active = false) noexcept;
+    Profile(QString && id,
+            QString && name,
+            QString && lastModified,
+            bool       active = false) noexcept;
 
     // Constructs copy
     Profile(const Profile & profile) = default;

--- a/source/QuickCutShared/Parser/BaseParser.h
+++ b/source/QuickCutShared/Parser/BaseParser.h
@@ -8,8 +8,8 @@ template <typename T>
 class BaseParser
 {
 protected:
-    BaseParser(const std::string & path);
-    BaseParser(std::string && path);
+    BaseParser(const QString & path);
+    BaseParser(QString && path);
     virtual ~BaseParser();
 
     virtual bool parseImpl(T * outData)   = 0;
@@ -19,22 +19,22 @@ public:
     bool parse(T * outData);
     bool save(const T & data);
 
-    const std::string & getFilePath();
+    const QString & getFilePath();
 
 protected:
-    JSON        m_Content;
-    std::string m_Path;
+    JSON    m_Content;
+    QString m_Path;
 };
 
 template <typename T>
-inline BaseParser<T>::BaseParser(std::string && path)
+inline BaseParser<T>::BaseParser(QString && path)
     : m_Path(std::move(path))
 {
     m_Content.clear();
 }
 
 template <typename T>
-inline BaseParser<T>::BaseParser(const std::string & path)
+inline BaseParser<T>::BaseParser(const QString & path)
     : m_Path(path)
 {
     m_Content.clear();
@@ -48,11 +48,11 @@ inline BaseParser<T>::~BaseParser()
 template <typename T>
 inline bool BaseParser<T>::parse(T * outData)
 {
-    if (m_Path.empty() || !outData) return false;
+    if (m_Path.isEmpty() || !outData) return false;
 
     try
     {
-        bpt::read_json(m_Path, m_Content);
+        bpt::read_json(qPrintable(m_Path), m_Content);
     }
     catch (const bpt::ptree_error & e)
     {
@@ -70,9 +70,9 @@ inline bool BaseParser<T>::parse(T * outData)
 template <typename T>
 inline bool BaseParser<T>::save(const T & data)
 {
-    if (m_Path.empty()) return false;
+    if (m_Path.isEmpty()) return false;
 
-    QFileInfo fi(QString::fromStdString(m_Path));
+    QFileInfo fi(m_Path);
     if (!fi.dir().exists()) fi.dir().mkpath(".");
 
     m_Content.clear();
@@ -81,7 +81,7 @@ inline bool BaseParser<T>::save(const T & data)
 
     try
     {
-        bpt::write_jsonEx(m_Path, m_Content);
+        bpt::write_jsonEx(qPrintable(m_Path), m_Content);
     }
     catch (const bpt::ptree_error & e)
     {
@@ -97,7 +97,7 @@ inline bool BaseParser<T>::save(const T & data)
 }
 
 template <typename T>
-inline const std::string & BaseParser<T>::getFilePath()
+inline const QString & BaseParser<T>::getFilePath()
 {
     return m_Path;
 }

--- a/source/QuickCutShared/Parser/PreferenceParser.cpp
+++ b/source/QuickCutShared/Parser/PreferenceParser.cpp
@@ -2,12 +2,12 @@
 #include "pch.h"
 #include "PreferenceParser.h"
 
-PreferenceParser::PreferenceParser(const std::string & path)
+PreferenceParser::PreferenceParser(const QString & path)
     : BaseParser(path)
 {
 }
 
-PreferenceParser::PreferenceParser(std::string && path)
+PreferenceParser::PreferenceParser(QString && path)
     : BaseParser(std::move(path))
 {
 }

--- a/source/QuickCutShared/Parser/PreferenceParser.h
+++ b/source/QuickCutShared/Parser/PreferenceParser.h
@@ -7,8 +7,8 @@
 class PreferenceParser : public BaseParser<Preference>
 {
 public:
-    PreferenceParser(const std::string & path);
-    PreferenceParser(std::string && path);
+    PreferenceParser(const QString & path);
+    PreferenceParser(QString && path);
     virtual ~PreferenceParser() = default;
 
 private:

--- a/source/QuickCutShared/Parser/ProfileParser.cpp
+++ b/source/QuickCutShared/Parser/ProfileParser.cpp
@@ -2,12 +2,12 @@
 #include "pch.h"
 #include "ProfileParser.h"
 
-ProfileParser::ProfileParser(std::string && path)
+ProfileParser::ProfileParser(QString && path)
     : BaseParser(std::move(path))
 {
 }
 
-ProfileParser::ProfileParser(const std::string & path)
+ProfileParser::ProfileParser(const QString & path)
     : BaseParser(path)
 {
 }
@@ -22,17 +22,17 @@ bool ProfileParser::parseImpl(std::vector<Profile *> * outData)
         outData->clear();
     }
 
-    std::string activeProfileId = m_Content.get<std::string>("activeProfile", "");
-    int         profileCount    = m_Content.get<int>("profileCount", 0);
+    QString activeProfileId = bpt::get(m_Content, "activeProfile", "");
+    int     profileCount    = m_Content.get<int>("profileCount", 0);
     outData->reserve(profileCount);
 
     JSON profilesJson = m_Content.get_child("profiles");
     for (auto && profileJson : profilesJson)
     {
-        std::string profileId    = profileJson.second.get<std::string>("id", "");
-        std::string profileName  = profileJson.second.get<std::string>("name", "");
-        std::string lastModified = profileJson.second.get<std::string>("lastModified", "");
-        int         actionsCount = profileJson.second.get<int>("actionsCount", 0);
+        QString profileId    = bpt::get(profileJson.second, "id", "");
+        QString profileName  = bpt::get(profileJson.second, "name", "");
+        QString lastModified = bpt::get(profileJson.second, "lastModified", "");
+        int     actionsCount = profileJson.second.get<int>("actionsCount", 0);
 
         Profile * profile = new Profile(std::move(profileId), std::move(profileName),
                                         std::move(lastModified), activeProfileId == profileId);
@@ -41,15 +41,15 @@ bool ProfileParser::parseImpl(std::vector<Profile *> * outData)
         JSON actionsJson = profileJson.second.get_child("actions");
         for (auto && actionJson : actionsJson)
         {
-            std::string actionId     = actionJson.second.get<std::string>("id", "");
-            std::string actionName   = actionJson.second.get<std::string>("actionName", "");
-            std::string actionType   = actionJson.second.get<std::string>("type", "");
-            std::string srcKey       = actionJson.second.get<std::string>("srcKey", "");
-            std::string dstKey       = actionJson.second.get<std::string>("dstKey", "");
-            std::string appPath      = actionJson.second.get<std::string>("appPath", "");
-            std::string appArgs      = actionJson.second.get<std::string>("appArgs", "");
-            std::string createdDate  = actionJson.second.get<std::string>("createdDate", "");
-            std::string lastModified = actionJson.second.get<std::string>("lastModified", "");
+            QString actionId     = bpt::get(actionJson.second, "id", "");
+            QString actionName   = bpt::get(actionJson.second, "actionName", "");
+            QString actionType   = bpt::get(actionJson.second, "type", "");
+            QString srcKey       = bpt::get(actionJson.second, "srcKey", "");
+            QString dstKey       = bpt::get(actionJson.second, "dstKey", "");
+            QString appPath      = bpt::get(actionJson.second, "appPath", "");
+            QString appArgs      = bpt::get(actionJson.second, "appArgs", "");
+            QString createdDate  = bpt::get(actionJson.second, "createdDate", "");
+            QString lastModified = bpt::get(actionJson.second, "lastModified", "");
 
             profile->getActionManager().add(new Action(actionId, actionName, lastModified,
                                                        Action::getType(actionType), srcKey,
@@ -64,37 +64,37 @@ bool ProfileParser::parseImpl(std::vector<Profile *> * outData)
 
 bool ProfileParser::saveImpl(const std::vector<Profile *> & data)
 {
-    std::string activeProfileId = "";
-    auto profileItr = std::find_if(data.begin(), data.end(), [&](const Profile * profile) {
+    QString activeProfileId = "";
+    auto    profileItr = std::find_if(data.begin(), data.end(), [&](const Profile * profile) {
         return profile->isActive();
     });
     if (profileItr != data.end()) activeProfileId = (*profileItr)->getId();
 
-    m_Content.put("activeProfile", activeProfileId);
+    bpt::put(m_Content, "activeProfile", activeProfileId);
     m_Content.put("profileCount", data.size());
 
     JSON profilesJson;
     for (auto && profile : data)
     {
         JSON profileJson;
-        profileJson.put("id", profile->getId());
-        profileJson.put("name", profile->getName());
-        profileJson.put("lastModified", profile->getLastModified());
+        bpt::put(profileJson, "id", profile->getId());
+        bpt::put(profileJson, "name", profile->getName());
+        bpt::put(profileJson, "lastModified", profile->getLastModified());
         profileJson.put("actionsCount", profile->getActionManager().count());
 
         JSON actionsJson;
         for (auto && action : profile->getActionManager())
         {
             JSON actionJson;
-            actionJson.put("id", action->getId());
-            actionJson.put("actionName", action->getName());
-            actionJson.put("type", Action::getType(action->getType()));
-            actionJson.put("srcKey", action->getSrcKey());
-            actionJson.put("dstKey", action->getDstKey());
-            actionJson.put("appPath", action->getAppPath());
-            actionJson.put("appArgs", action->getAppArgs());
-            actionJson.put("createdDate", action->getCreatedDate());
-            actionJson.put("lastModified", action->getLastModified());
+            bpt::put(actionJson, "id", action->getId());
+            bpt::put(actionJson, "actionName", action->getName());
+            bpt::put(actionJson, "type", Action::getType(action->getType()));
+            bpt::put(actionJson, "srcKey", action->getSrcKey());
+            bpt::put(actionJson, "dstKey", action->getDstKey());
+            bpt::put(actionJson, "appPath", action->getAppPath());
+            bpt::put(actionJson, "appArgs", action->getAppArgs());
+            bpt::put(actionJson, "createdDate", action->getCreatedDate());
+            bpt::put(actionJson, "lastModified", action->getLastModified());
 
             actionsJson.push_back(std::make_pair("", actionJson));
         }

--- a/source/QuickCutShared/Parser/ProfileParser.h
+++ b/source/QuickCutShared/Parser/ProfileParser.h
@@ -7,8 +7,8 @@
 class ProfileParser : public BaseParser<std::vector<Profile *>>
 {
 public:
-    ProfileParser(std::string && path);
-    ProfileParser(const std::string & path);
+    ProfileParser(QString && path);
+    ProfileParser(const QString & path);
     virtual ~ProfileParser();
 
 private:

--- a/source/QuickCutShared/Utils/Utility.cpp
+++ b/source/QuickCutShared/Utils/Utility.cpp
@@ -23,6 +23,18 @@ namespace boost
             file << result;
             file.close();
         }
+
+        QString get(JSON & ptree, const QString & path, const QString & defaultValue)
+        {
+            std::string result = ptree.get<std::string>(std::string(qPrintable(path)),
+                                                        std::string(qPrintable(defaultValue)));
+            return QString::fromStdString(result);
+        }
+
+        JSON & put(JSON & ptree, const QString & path, const QString & value)
+        {
+            return ptree.put(std::string(qPrintable(path)), std::string(qPrintable(value)));
+        }
     } // namespace property_tree
 } // namespace boost
 
@@ -61,10 +73,10 @@ namespace Hook
 
 namespace QuickCut
 {
-    std::string getDateTime()
+    QString getDateTime()
     {
-        return QDateTime::currentDateTime().toString(Qt::DateFormat::ISODate).toStdString();
+        return QDateTime::currentDateTime().toString(Qt::DateFormat::ISODate);
     }
 
-    std::string createUuid() { return QUuid::createUuid().toString().toStdString(); }
+    QString createUuid() { return QUuid::createUuid().toString(); }
 } // namespace QuickCut

--- a/source/QuickCutShared/Utils/Utility.h
+++ b/source/QuickCutShared/Utils/Utility.h
@@ -12,6 +12,9 @@ namespace boost
          * this function will parse the input and make the json file look as it should be.
          */
         void write_jsonEx(const std::string & path, const JSON & ptree);
+
+        QString get(JSON & ptree, const QString & path, const QString & defaultValue);
+        JSON &  put(JSON & ptree, const QString & path, const QString & value);
     } // namespace property_tree
 } // namespace boost
 
@@ -27,6 +30,6 @@ namespace Hook
 
 namespace QuickCut
 {
-    std::string getDateTime();
-    std::string createUuid();
+    QString getDateTime();
+    QString createUuid();
 } // namespace QuickCut


### PR DESCRIPTION
This simplifies the code base significantly by reducing the overhead of using QString::fromStdString and QString::toStdString.