### PR TITLE
Implement IPC mechanism to notify QuickCutConsole to reload profiles.

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -16,21 +16,12 @@ set(QUICKCUT_SHARED_DIR ${SOURCE_ROOT_DIR}/QuickCutShared CACHE STRING "")
 
 # TODO(Gilad): Consider implementing a fall back scenarios, where if we could'nt find the packages, try finding
 # if conan installed, if installed, do "conan install .." command and try to find again after conan setup.
-if(WIN32)
-    find_package(Qt5 REQUIRED COMPONENTS
-        Core
-        Widgets
-        Gui
-    )
-else() # UNIX
-    find_package(Qt5 REQUIRED COMPONENTS
-        Core
-        Widgets
-        Gui
-        Network
-    )
-endif()
-
+find_package(Qt5 REQUIRED COMPONENTS
+    Core
+    Widgets
+    Gui
+    Network
+)
 if (Qt5_FOUND)
     message(STATUS "[INFO] Qt5 Found -> ${Qt5_DIR}")
 else()

--- a/source/QuickCut/CMakeLists.txt
+++ b/source/QuickCut/CMakeLists.txt
@@ -189,10 +189,11 @@ add_executable(${PROJECT_NAME}
 
 if(WIN32)
     target_link_libraries(${PROJECT_NAME} PUBLIC
+        Qt5::WinMain
         Qt5::Core
         Qt5::Gui
         Qt5::Widgets
-        Qt5::WinMain
+        Qt5::Network
     )
 else() # UNIX
     target_link_libraries(${PROJECT_NAME} PUBLIC

--- a/source/QuickCut/MainWindow.h
+++ b/source/QuickCut/MainWindow.h
@@ -11,6 +11,7 @@ class ExamplesWindow;
 class CheckUpdatesWindow;
 class AboutWindow;
 class ActionEditWindow;
+class QLocalSocket;
 
 class MainWindow : public QMainWindow
 {
@@ -29,6 +30,8 @@ public:
     bool loadProfiles();
     bool reloadProfiles();
     bool saveProfiles();
+
+    bool sendReloadProfiles();
 
     void showEvent(QShowEvent * event) override;
 
@@ -51,6 +54,8 @@ public slots:
 
     void onActionSaved();
     void onActionCreated(Action * action);
+
+    void onReloadProfilesResponse();
 
     // File Menu
     void onActionFileOpen();
@@ -83,4 +88,8 @@ private:
 
     ProfileManager    m_Profiles;
     PreferenceManager m_Preference;
+
+    QLocalSocket * m_LocalSocket;
+    QDataStream    m_SocketStreamIn;
+    int            m_SocketBlockSize;
 };

--- a/source/QuickCutConsole/CMakeLists.txt
+++ b/source/QuickCutConsole/CMakeLists.txt
@@ -146,10 +146,12 @@ if(WIN32)
     target_link_libraries(${PROJECT_NAME} PUBLIC
         Qt5::WinMain
         Qt5::Core
+        Qt5::Network
     )
 else() # UNIX
     target_link_libraries(${PROJECT_NAME} PUBLIC
         Qt5::Core
+        Qt5::Network
     )
 endif()
 

--- a/source/QuickCutConsole/QuickCutConsole.h
+++ b/source/QuickCutConsole/QuickCutConsole.h
@@ -6,11 +6,12 @@
 
 class Profile;
 class ProfileManager;
+class QLocalServer;
 
 class QuickCutConsole : public QCoreApplication
 {
 
-public:
+protected:
     QuickCutConsole(int argc, char * argv[]);
     virtual ~QuickCutConsole();
 
@@ -21,9 +22,15 @@ public:
     static void executeProcess(const QString & process, const QString & arguments);
     static void log(const QString & filePath, const QString & text);
 
-public:
+    static bool notifyStatusToClient(const QString & message);
+
+protected:
     static QuickCutConsole * s_Instance;
     static Profile *         s_Profile;
+
+    // Will be used for signaling when the GUI updates the profiles.json file, the server will
+    // reload the profiles in order to get things synchronized.
+    static QLocalServer * s_LocalSocket;
 
 private:
     static ProfileManager s_ProfileManager;

--- a/source/QuickCutConsole/QuickCutConsoleWindows.cpp
+++ b/source/QuickCutConsole/QuickCutConsoleWindows.cpp
@@ -3,10 +3,6 @@
 #include "QuickCutConsoleWindows.h"
 #include "Managers/ProfileManager.h"
 
-// The GUI will send this pattern of key codes to notify that profile changes has been made
-// so it knows when to reload the profile data.
-#define RESERVED_RELOAD_KEY "86878687"
-
 #define KEY_WAS_DOWN_MASK 0x80
 #define KEY_IS_DOWN_MASK  0x01
 
@@ -58,16 +54,6 @@ LRESULT CALLBACK QuickCutConsoleWindows::WndProc(int nCode, WPARAM wParam, LPARA
 
         pressedKeys += QString::number(kbd->vkCode, 16);
         printKeyName(kbd, pressedKeys);
-
-        if (pressedKeys == RESERVED_RELOAD_KEY)
-        {
-            loadProfiles();
-            qDebug() << "Refresh signal requested. Reloading profiles.";
-            pressedKeys.clear();
-            keysAlreadyProcessed = false;
-            prevVkCode           = 0;
-            return CallNextHookEx(s_Hook, nCode, wParam, lParam);
-        }
 
         if (!s_Profile) { return CallNextHookEx(s_Hook, nCode, wParam, lParam); }
 

--- a/source/QuickCutService/CMakeLists.txt
+++ b/source/QuickCutService/CMakeLists.txt
@@ -112,6 +112,7 @@ if(WIN32)
     target_link_libraries(${PROJECT_NAME} PUBLIC
         Qt5::WinMain
         Qt5::Core
+        Qt5::Network
     )
 else() # UNIX
     target_link_libraries(${PROJECT_NAME} PUBLIC

--- a/source/QuickCutShared/Models/Action.cpp
+++ b/source/QuickCutShared/Models/Action.cpp
@@ -1,7 +1,6 @@
 
 #include "pch.h"
 #include "Action.h"
-#include "Utils/Utility.h"
 
 Action::Action() noexcept
     : BaseModel()

--- a/source/QuickCutShared/Models/BaseModel.cpp
+++ b/source/QuickCutShared/Models/BaseModel.cpp
@@ -1,7 +1,6 @@
 
 #include "pch.h"
 #include "BaseModel.h"
-#include "Utils/Utility.h"
 
 // TODO(Gilad): Manage lastModified differently after finishing refactoring.
 

--- a/source/QuickCutShared/Types.h
+++ b/source/QuickCutShared/Types.h
@@ -3,6 +3,9 @@
 
 #include <boost/property_tree/json_parser.hpp>
 
+#define QUICKCUT_VERSION "2.0.0"
+#define QUICKCUT_IPC     "QuickCut_IPC_" QUICKCUT_VERSION
+
 namespace bpt = boost::property_tree;
 typedef bpt::ptree JSON;
 

--- a/source/QuickCutShared/Utils/Utility.cpp
+++ b/source/QuickCutShared/Utils/Utility.cpp
@@ -1,6 +1,6 @@
 
 #include "pch.h"
-#include "Utils/Utility.h"
+#include "Utility.h"
 
 #include <QDateTime>
 #include <QUuid>
@@ -37,39 +37,6 @@ namespace boost
         }
     } // namespace property_tree
 } // namespace boost
-
-namespace Hook
-{
-#if defined(Q_OS_WIN)
-    void sendReloadSignal()
-    {
-        const int INPUT_COUNT     = 4;
-        int       vkKey1          = std::strtol("86", nullptr, 16);
-        int       vkKey2          = std::strtol("87", nullptr, 16);
-        INPUT     in[INPUT_COUNT] = {0};
-        for (int i = 0; i < INPUT_COUNT; i++)
-        {
-            in[i].type       = INPUT_KEYBOARD;
-            in[i].ki.dwFlags = KEYEVENTF_UNICODE;
-            in[i].ki.wVk     = (i % 2 == 0) ? vkKey1 : vkKey2;
-        }
-        SendInput(INPUT_COUNT, in, sizeof(INPUT));
-
-        // Sending key up, which should reset the key codes pattern and profiles has been
-        // reloaded.
-        INPUT inUp      = {0};
-        inUp.type       = INPUT_KEYBOARD;
-        inUp.ki.dwFlags = KEYEVENTF_KEYUP;
-        inUp.ki.wVk     = vkKey1;
-        SendInput(1, &inUp, sizeof(INPUT));
-    }
-#elif defined(Q_OS_UNIX)
-    void sendReloadSignal()
-    {
-        // TODO(Gilad): Implement.
-    }
-#endif
-} // namespace Hook
 
 namespace QuickCut
 {

--- a/source/QuickCutShared/Utils/Utility.h
+++ b/source/QuickCutShared/Utils/Utility.h
@@ -18,16 +18,6 @@ namespace boost
     } // namespace property_tree
 } // namespace boost
 
-namespace Hook
-{
-    /*
-     * The keyboard hook will check if this key pattern matched, if it matched,
-     * it will reload the profiles file so changes will take affect on the
-     * system without having to restart the application nor the service.
-     */
-    void sendReloadSignal();
-} // namespace Hook
-
 namespace QuickCut
 {
     QString getDateTime();

--- a/source/QuickCutShared/pch.h
+++ b/source/QuickCutShared/pch.h
@@ -17,11 +17,14 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QProcess>
+#include <QtNetwork>
+#include <QLocalSocket>
 #include <QTextStream>
 #include <QStandardPaths>
 
 // Project includes
 #include "Types.h"
+#include "Utils/Utility.h"
 
 // Other includes
 #if defined(Q_OS_WIN)


### PR DESCRIPTION
Using QLocalSocket is a better approach for this IPC scenario where it requires to notify the QuickCutConsole to reload the profiles on every modifications that are made by the QuickCut GUI.
This also get ride of the concern of writing platform specific code.